### PR TITLE
:sparkles: Add DynamoDB extension

### DIFF
--- a/src/Musement.AWSExtensions/Musement.AWSExtensions.csproj
+++ b/src/Musement.AWSExtensions/Musement.AWSExtensions.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="$(AWSSDKVersion)" />
     <PackageReference Include="Kralizek.Extensions.Configuration.AWSSecretsManager" Version="1.6.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.*" />
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="$(AWSSDKVersion)" />

--- a/src/Musement.AWSExtensions/ServicesExtensions.cs
+++ b/src/Musement.AWSExtensions/ServicesExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using Amazon;
+using Amazon.DynamoDBv2;
 using Amazon.Extensions.NETCore.Setup;
 using Amazon.Runtime;
 using Amazon.S3;
@@ -103,5 +104,22 @@ public static class ServicesExtensions
         {
             Region = RegionEndpoint.EUWest1
         });
+    }
+
+    public static IServiceCollection AddAmazonDynamoDb(this IServiceCollection self)
+    {
+        if (UseLocalstack)
+        {
+            var config = new AmazonDynamoDBConfig
+            {
+                ServiceURL = LocalstackEndpoint,
+                UseHttp = true
+            };
+
+            var client = new AmazonDynamoDBClient(FakeCredentials, config);
+            return self.AddSingleton<IAmazonDynamoDB>(client);
+        }
+
+        return self.AddAWSService<IAmazonDynamoDB>();
     }
 }


### PR DESCRIPTION
Added the missing Localstack-aware extension for AWS DynamoDB. 